### PR TITLE
Support file paths with spaces.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -62,7 +62,7 @@ define(function(require, exports) {
 		// Remove file:// prefix
 		if (fullPath.indexOf("://") != -1) {
 			var fileUri = new URL(fullPath);
-			fullPath = fileUri.pathname;
+			fullPath = decodeURI(fileUri.pathname);
 
 			// Convert /D:/path to D:/Path
 			if (fullPath.indexOf("/") === 0 && fullPath.indexOf(":") > 0) {

--- a/lib/xdebug.js
+++ b/lib/xdebug.js
@@ -53,7 +53,7 @@ define(function(require, exports) {
 
 		for (key in args) {
 			if (typeof args[key] != "undefined") {
-				command.push(" -" + key + " " + args[key]);
+				command.push(" -" + key + ' "' + args[key] + '"');
 			}
 		}
 


### PR DESCRIPTION
Fixes support for debugging files with spaces in its path by wrapping xdebug command args in quotes and by URI decoding the filepath in responses.
