### PR TITLE
Add missing URI decode

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -59,6 +59,9 @@ define(function(require, exports) {
 	}
 
 	function toEditorPath(fullPath) {
+		// Decode URI
+		fullPath = decodeURI(fullPath);
+		
 		// Remove file:// prefix
 		if (fullPath.indexOf("://") != -1) {
 			fullPath = fullPath.replace("file:///", "/");


### PR DESCRIPTION
Fixes missing URI decode that was accidentally removed in 29a0a30edde2bdd495840925eee0c93743af8c46
