### PR TITLE
Enable remote debugging

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -96,6 +96,7 @@ define(function(require, exports) {
 		isActive = true;
 		panel.toggle(true);
 		console.clear();
+		util.setProjectRoot();
 		xdebug.startServer();
 		$("#editor-holder").addClass("php-debugger");
 		editor.refresh();

--- a/lib/editor.js
+++ b/lib/editor.js
@@ -251,7 +251,7 @@ define(function(require, exports) {
 		}
 	}
 
-	exports.open = function(fullPath) {
+	function open(fullPath) {
 		var deferred = $.Deferred(), isOpen;
 
 		fullPath = util.toEditorPath(fullPath);
@@ -295,7 +295,7 @@ define(function(require, exports) {
 			return;
 		}
 
-		return exports.open(fullPath).done(function(editor) {
+		return open(fullPath).done(function(editor) {
 			editor.setCursorPos(lineNo);
 			editor.focus();
 		});
@@ -307,7 +307,7 @@ define(function(require, exports) {
 			return;
 		}
 
-		return exports.open(fullPath).done(function(editor) {
+		return open(fullPath).done(function(editor) {
 			editor.setCursorPos(lineNo);
 			toggleActiveLine(editor, currentDocActiveLine, false);
 			toggleActiveLine(editor, lineNo, true);

--- a/lib/editor.js
+++ b/lib/editor.js
@@ -6,6 +6,7 @@ define(function(require, exports) {
 		Commands = brackets.getModule("command/Commands"),
 		EditorManager = brackets.getModule("editor/EditorManager"),
 		DocumentManager = brackets.getModule("document/DocumentManager"),
+		console = require("./console"),
 		panel = require("./panel"),
 		util = require("./util");
 
@@ -289,6 +290,11 @@ define(function(require, exports) {
 	};
 
 	exports.gotoLine = function(fullPath, lineNo) {
+		if (!util.canOpenRemotePath(fullPath)) {
+			console.log("Cannot open remote path: " + util.toEditorPath(fullPath) + " @ line " + lineNo);
+			return;
+		}
+
 		return exports.open(fullPath).done(function(editor) {
 			editor.setCursorPos(lineNo);
 			editor.focus();
@@ -296,6 +302,11 @@ define(function(require, exports) {
 	};
 
 	exports.setActiveLine = function(fullPath, lineNo) {
+		if (!util.canOpenRemotePath(fullPath)) {
+			console.log("Cannot show remote path: " + util.toEditorPath(fullPath) + " @ line " + lineNo);
+			return;
+		}
+
 		return exports.open(fullPath).done(function(editor) {
 			editor.setCursorPos(lineNo);
 			toggleActiveLine(editor, currentDocActiveLine, false);

--- a/lib/util.js
+++ b/lib/util.js
@@ -2,6 +2,32 @@
  * Module with various utility functions.
  */
 define(function(require, exports) {
+	var ProjectManager = brackets.getModule("project/ProjectManager");
+	var console = require("./console");
+
+	var pathMap = {};
+	var projectRoot = null;
+	var remoteProjectRoot = null;
+
+	function setProjectRoot() {
+		var currentProjectRoot = ProjectManager.getProjectRoot().fullPath;
+
+		if (currentProjectRoot !== projectRoot) {
+			projectRoot = currentProjectRoot;
+
+			if (pathMap[projectRoot]) {
+				remoteProjectRoot = pathMap[projectRoot];
+				console.log("Using path map: " + projectRoot + ":" + remoteProjectRoot);
+				return;
+			} else if (projectRoot) {
+				console.log("No path map found for: " + projectRoot);
+			} else {
+				console.log("Could not determine project root");
+			}
+			remoteProjectRoot = null;
+		}
+	}
+
 	function propertyToJson($elm) {
 		function populateValue(property, $elm) {
 			switch (property.type) {
@@ -58,7 +84,7 @@ define(function(require, exports) {
 		return walk($elm);
 	}
 
-	function toEditorPath(fullPath) {
+	function normalizePath(fullPath) {
 		// Decode URI
 		fullPath = decodeURI(fullPath);
 		
@@ -80,15 +106,38 @@ define(function(require, exports) {
 		return fullPath;
 	}
 
+	function toEditorPath(fullPath) {
+		fullPath = normalizePath(fullPath);
+
+		// Map remote project path to local
+		if (remoteProjectRoot) {
+			var pathReplace = new RegExp('^' + remoteProjectRoot);
+			fullPath = fullPath.replace(pathReplace, projectRoot);
+		}
+
+		return fullPath;
+	}
+
 	function toXdebugPath(filePath) {
-		filePath = toEditorPath(filePath);
+		filePath = normalizePath(filePath);
 
 		// Add slash before drive letter
 		filePath = filePath.replace(/^[a-z0-9]:/i, function(m) {
 			return "/" + m;
 		});
 
+		// Map local project path to remote
+		if (remoteProjectRoot) {
+			var pathReplace = new RegExp('^' + projectRoot);
+			filePath = filePath.replace(pathReplace, remoteProjectRoot);
+		}
+
 		return "file://" + filePath;
+	}
+
+	function canOpenRemotePath(fullPath) {
+		var match = new RegExp('^' + projectRoot);
+		return match.test(toEditorPath(fullPath));
 	}
 
 	function attachCommand($elm, cmd, args) {
@@ -116,10 +165,23 @@ define(function(require, exports) {
 		return str.substr(0, frontChars) + "..." + str.substr(str.length - backChars);
 	}
 
+	function init(opts) {
+		// Make sure trailing slashes are present on paths.
+		if (typeof opts.pathMap === "object") {
+			pathMap = {};
+			Object.keys(opts.pathMap).forEach(function (key) {
+				pathMap[key.replace(/\/+$/, '') + "/"] = opts.pathMap[key].replace(/\/+$/, '') + "/";
+			});
+		}
+	}
+
 	$.extend(exports, {
+		init: init,
+		setProjectRoot: setProjectRoot,
 		propertyToJson: propertyToJson,
 		toEditorPath: toEditorPath,
 		toXdebugPath: toXdebugPath,
+		canOpenRemotePath: canOpenRemotePath,
 		attachCommand: attachCommand,
 		comparePaths: comparePaths,
 		shorten: shorten

--- a/lib/util.js
+++ b/lib/util.js
@@ -173,6 +173,9 @@ define(function(require, exports) {
 				pathMap[key.replace(/\/+$/, '') + "/"] = opts.pathMap[key].replace(/\/+$/, '') + "/";
 			});
 		}
+
+		// Update projectRoot if open project changes.
+		$(ProjectManager).on("projectOpen", setProjectRoot);
 	}
 
 	$.extend(exports, {

--- a/lib/xdebug.js
+++ b/lib/xdebug.js
@@ -104,7 +104,7 @@ define(function(require, exports) {
 		breakPoints.forEach(function(breakPoint) {
 			var promise = execute("breakpoint_set", {
 				t: "line",
-				f: breakPoint.fullPath,
+				f: util.toXdebugPath(breakPoint.fullPath),
 				n: breakPoint.line + 1
 			});
 

--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@ define(function(require, exports, module) {
 		commands = require('./lib/commands'),
 		tree = require('./lib/tree'),
 		editor = require('./lib/editor'),
+		utils = require('./lib/util'),
 		Menus = brackets.getModule("command/Menus"),
 		AppInit = brackets.getModule("utils/AppInit"),
 		CommandManager = brackets.getModule("command/CommandManager"),
@@ -88,6 +89,9 @@ define(function(require, exports, module) {
 		commands.init();
 		tree.init();
 		editor.init();
+		utils.init({
+			pathMap: prefs.get('pathMap') || {}
+		});
 	}
 
 	function bindEvents() {

--- a/node/xdebug.js
+++ b/node/xdebug.js
@@ -72,7 +72,7 @@ function Server() {
 				self.emit("connect", session);
 			});
 
-			server.listen(args[0], "localhost");
+			server.listen(args[0]);
 		}
 
 		callback(null, null);


### PR DESCRIPTION
This fixes #16.

This PR provides some mapping functions in `lib/util.js` (extending one that was stubbed out, so I think this was a planned approach). They enable path translation between a local code base in Brackets and a remote instance of Xdebug (e.g., in a VM or Docker container). It also removes the binding to `localhost` that prevents Xdebug from connecting in the first place.

The user can set a preference in `brackets.json` that maps project roots to remote paths, e.g.:

``` json
"php-debugger.pathMap": {
  "/Users/admin/Documents/myProject/": "/var/www/myProject/"
}
```

Now, php-debugger can properly map breakpoints to a remote Xdebug instance, and can open local files while stepping through code. If the file is not available locally (because it is outside the mapping defined in the user preference), a note will be logged to the php-debugger console.

A note is also logged to let the user know whether or not a path map is being used.
